### PR TITLE
Add support for more than 32 channel, NSMS, and LARD modules

### DIFF
--- a/playptmod.c
+++ b/playptmod.c
@@ -1046,7 +1046,7 @@ static void checkModType(MODULE_HEADER *h, player *p, const char *buf)
         p->maxPeriod = PT_MAX_PERIOD;
         return;
     }
-    else if (!strncmp(buf, "CD", 2) && buf[0] >= '1' && buf[0] <= '9' && !strncmp(buf + 3, "1", 1))
+    else if (!strncmp(buf, "CD", 2) && buf[2] >= '1' && buf[2] <= '9' && !strncmp(buf + 3, "1", 1))
     {
         h->format = FORMAT_NCHN; /* Octalyzer (Atari STE/Falcon) */
         p->numChans = h->channelCount = buf[2] - '0';

--- a/playptmod.h
+++ b/playptmod.h
@@ -10,20 +10,20 @@ enum
     FORMAT_MK,     // ProTracker 1.x
     FORMAT_MK2,    // ProTracker 2.x (if tune has >64 patterns)
     FORMAT_FLT4,   // StarTrekker
-    FORMAT_FLT8,
-    FORMAT_NCHN,   // FastTracker II (only 1-9 channel MODs)
-    FORMAT_NNCH,   // FastTracker II (10-32 channel MODs)
-    FORMAT_16CN,   // FastTracker II (16 channel MODs)
-    FORMAT_32CN,   // FastTracker II (32 channel MODs)
+    FORMAT_FLT8,   // StarTrekker
+    FORMAT_NCHN,   // FastTracker II/TakeTracker (1-9 channel MODs)
+    FORMAT_NNCH,   // FastTracker II/TakeTracker (10-99 channel MODs)
+    FORMAT_NNNC,   // (100-999 channel MODs)
+    FORMAT_NNCN,   // TakeTracker (10-99 channel MODs)
     FORMAT_STK,    // The Ultimate SoundTracker (15 samples)
     FORMAT_NT,     // NoiseTracker 1.0
     FORMAT_FEST,   // NoiseTracker (special ones)
-    
+
     FORMAT_MTM,    // MultiTracker
-    
+
     FORMAT_UNKNOWN
 };
-    
+
 void * playptmod_Create(int samplingFrequency);
 
 #define PTMOD_OPTION_CLAMP_PERIODS 0


### PR DESCRIPTION
The player is missing some MOD magic formats so I decided to fix the code so it supports other MOD formats like DigiTracker as well.